### PR TITLE
add missing dependency to catkin_package()

### DIFF
--- a/geographic_msgs/CMakeLists.txt
+++ b/geographic_msgs/CMakeLists.txt
@@ -41,5 +41,5 @@ generate_messages(
 )
 
 catkin_package(
-  CATKIN_DEPENDS message_runtime uuid_msgs std_msgs
+  CATKIN_DEPENDS message_runtime geometry_msgs uuid_msgs std_msgs
 )


### PR DESCRIPTION
Message generation depends on geometry_msgs, thus this dependency must be propagated in catkin_package().
