### PR TITLE
New Version of GetGeoPath srv.

### DIFF
--- a/geographic_msgs/msg/GeoPath.msg
+++ b/geographic_msgs/msg/GeoPath.msg
@@ -1,2 +1,7 @@
 std_msgs/Header header
-geographic_msgs/GeoPoseStamped[] poses
+
+geographic_msgs/GeoPoint[] points
+uuid_msgs/UniqueID network
+uuid_msgs/UniqueID start_seg
+uuid_msgs/UniqueID goal_seg
+float64 distance

--- a/geographic_msgs/msg/GeoPath.msg
+++ b/geographic_msgs/msg/GeoPath.msg
@@ -1,7 +1,2 @@
 std_msgs/Header header
-
-geographic_msgs/GeoPoint[] points
-uuid_msgs/UniqueID network
-uuid_msgs/UniqueID start_seg
-uuid_msgs/UniqueID goal_seg
-float64 distance
+geographic_msgs/GeoPoseStamped[] poses

--- a/geographic_msgs/srv/GetGeoPath.srv
+++ b/geographic_msgs/srv/GetGeoPath.srv
@@ -10,3 +10,8 @@ bool success                          # true if the call succeeded
 string status                         # more details
 
 geographic_msgs/GeoPath plan          # path to follow
+
+uuid_msgs/UniqueID network            # the uuid of the RouteNetwork
+uuid_msgs/UniqueID start_seg          # the uuid of the starting RouteSegment
+uuid_msgs/UniqueID goal_seg           # the uuid of the ending RouteSegment
+float64 distance                      # the length of the plan


### PR DESCRIPTION
This PR simply extends the response of the GetGeoPath service, by returning additional information such as the length of the computed path. This extension is needed in order for the planning between GeoPoints within packages 'route_network' and 'osm_cartography' to work.