### PR TITLE
[Ros2] clean cmake and package.xml for geographic_msgs

### DIFF
--- a/geographic_msgs/CMakeLists.txt
+++ b/geographic_msgs/CMakeLists.txt
@@ -1,22 +1,26 @@
 cmake_minimum_required(VERSION 3.5)
 project(geographic_msgs)
 
-# Add support for C++11
+# Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(uuid_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(builtin_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(uuid_msgs REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME} 
+set(msg_files
   "msg/BoundingBox.msg"
-  "msg/GeographicMapChanges.msg" 
-  "msg/GeographicMap.msg" 
+  "msg/GeographicMapChanges.msg"
+  "msg/GeographicMap.msg"
   "msg/GeoPath.msg"
   "msg/GeoPoint.msg"
   "msg/GeoPointStamped.msg"
@@ -28,37 +32,24 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/RoutePath.msg"
   "msg/RouteSegment.msg"
   "msg/WayPoint.msg"
+)
+
+set(srv_files
   "srv/GetGeographicMap.srv"
   "srv/GetGeoPath.srv"
   "srv/GetRoutePlan.srv"
   "srv/UpdateGeographicMap.srv"
-  DEPENDENCIES 
-  builtin_interfaces
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  ${srv_files}
+  DEPENDENCIES
+  geometry_msgs
   std_msgs
-  geometry_msgs 
   uuid_msgs
 )
 
-set(INCLUDE_DIRS ${ament_cmake_INCLUDE_DIRS} ${std_msgs_INCLUDE_DIRS}
-  ${geometry_msgs_INCLUDE_DIRS} ${uuid_msgs_INCLUDE_DIRS}
-  ${rosidl_default_generators_INCLUDE_DIRS})
-include_directories(${INCLUDE_DIRS})
-
-set(LIBRARY_DIRS ${ament_cmake_LIBRARY_DIRS} ${std_msgs_LIBRARY_DIRS}
-  ${geometry_msgs_LIBRARY_DIRS} ${uuid_msgs_LIBRARY_DIRS}
-  ${rosidl_default_generators_LIBRARY_DIRS})
-
-link_directories(${LIBRARY_DIRS})
-
-set(LIBS ${ament_cmake_LIBRARIES} ${std_msgs_LIBRARIES}
-  ${geometry_msgs_LIBRARIES} ${uuid_msgs_LIBRARIES}
-  ${rosidl_default_generators_LIBRARIES})
-
-ament_export_dependencies(ament_cmake)
-ament_export_dependencies(std_msgs)
-ament_export_dependencies(geometry_msgs)
-ament_export_dependencies(uuid_msgs)
-ament_export_dependencies(rosidl_default_generators)
-ament_export_include_directories(${INCLUDE_DIRS})
+ament_export_dependencies(rosidl_default_runtime)
 
 ament_package()

--- a/geographic_msgs/package.xml
+++ b/geographic_msgs/package.xml
@@ -1,4 +1,5 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
 
   <name>geographic_msgs</name>
@@ -16,20 +17,18 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>uuid_msgs</build_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <exec_depend>message_runtime</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>uuid_msgs</exec_depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>uuid_msgs</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
- <buildtool_depend>rosidl_default_generators</buildtool_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>
   </export>
+
 </package>


### PR DESCRIPTION
I came across this when trying to use mavros with ROS 2.

This is mostly simplifying the CMake logic for the message package.

@matt-attack as the original contributor of the ROS2 port, can you confirm that this still works for your use case?