### PR TITLE
add missing build type so that catkin flags are not passed to cmake

### DIFF
--- a/geographic_info/CMakeLists.txt
+++ b/geographic_info/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.5)
-project(geographic_info)
+project(geographic_info NONE)
 find_package(ament_cmake REQUIRED)
 ament_package()

--- a/geographic_info/package.xml
+++ b/geographic_info/package.xml
@@ -22,4 +22,7 @@
   <depend>geodesy</depend>
   <depend>geographic_msgs</depend>
 
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
Otherwise this package generates CMake warnings when building

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>