### PR TITLE
Python3 fixes

### DIFF
--- a/geodesy/src/geodesy/wu_point.py
+++ b/geodesy/src/geodesy/wu_point.py
@@ -53,7 +53,7 @@ import geodesy.utm
 from geographic_msgs.msg import WayPoint
 from geometry_msgs.msg import Point
 
-class WuPoint():
+class WuPoint:
     """
     :class:`WuPoint` represents a map way point with associated UTM_
     information.
@@ -111,7 +111,7 @@ class WuPoint():
         """:returns: UUID_ of way point. """
         return self.way_pt.id.uuid
 
-class WuPointSet():
+class WuPointSet:
     """
     :class:`WuPointSet` is a container for the way points in a
     `geographic_msgs/GeographicMap`_ or
@@ -159,12 +159,12 @@ class WuPointSet():
         # Initialize way point information.
         self.way_point_ids = {}         # points symbol table
         self.n_points = len(self.points)
-        for wid in xrange(self.n_points):
-            self.way_point_ids[self.points[wid].id.uuid] = wid
+        for wid in range(self.n_points):
+            self.way_point_ids[str(self.points[wid].id.uuid)] = wid
 
         # Create empty list of UTM points, corresponding to map points.
         # They will be evaluated lazily, when first needed.
-        self.utm_points = [None for wid in xrange(self.n_points)]
+        self.utm_points = [None for wid in range(self.n_points)]
 
     def __contains__(self, item):
         """ Point set membership. """
@@ -187,6 +187,9 @@ class WuPointSet():
     def __len__(self):
         """Point set length."""
         return self.n_points
+
+    def __next__(self):
+        return self.next()
 
     def _get_point_with_utm(self, index):
         """Get way point with UTM coordinates.

--- a/geodesy/tests/test_bounding_box.py
+++ b/geodesy/tests/test_bounding_box.py
@@ -4,6 +4,9 @@ import unittest
 
 from geodesy.bounding_box import *     # module being tested
 
+suite = unittest.TestSuite()
+
+
 class TestPythonBoundingBox(unittest.TestCase):
     """Unit tests for Python bounding box functions. """
 
@@ -44,7 +47,7 @@ class TestPythonBoundingBox(unittest.TestCase):
         self.assertEqual(max_lon, max_lon2)
         self.assertEqual(max_alt, bb.max_pt.altitude)
 
+
 if __name__ == '__main__':
-    import rosunit
-    PKG='geodesy'
-    rosunit.unitrun(PKG, 'test_uuid_py', TestPythonBoundingBox) 
+    runner = unittest.TextTestRunner(verbosity=3)
+    result = runner.run(suite)

--- a/geodesy/tests/test_props.py
+++ b/geodesy/tests/test_props.py
@@ -10,6 +10,9 @@ from geographic_msgs.msg import MapFeature
 from geographic_msgs.msg import RouteSegment
 from geographic_msgs.msg import WayPoint
 
+suite = unittest.TestSuite()
+
+
 class TestPythonProps(unittest.TestCase):
     """Unit tests for Python KeyValue property handling.
     """
@@ -70,7 +73,7 @@ class TestPythonProps(unittest.TestCase):
         self.assertEqual(get(f, 'notset'), 'any')
         self.assertRaises(ValueError, match, f, 'notset')
 
+
 if __name__ == '__main__':
-    import rosunit
-    PKG='geodesy'
-    rosunit.unitrun(PKG, 'test_uuid_py', TestPythonProps) 
+    runner = unittest.TextTestRunner(verbosity=3)
+    result = runner.run(suite)

--- a/geodesy/tests/test_utm.py
+++ b/geodesy/tests/test_utm.py
@@ -5,6 +5,9 @@ import unittest
 
 from geodesy.utm import *
 
+suite = unittest.TestSuite()
+
+
 ## A sample python unit test
 class TestUTMPoint(unittest.TestCase):
 
@@ -45,7 +48,7 @@ class TestUTMPoint(unittest.TestCase):
         self.assertTrue(pt.valid(), msg='invalid UTMPoint: ' + str(pt))
         self.assertTrue(pt.is2D(), msg='this UTMPoint should be 2D: ' + str(pt))
         self.assertEqual(pt.gridZone(), (14, 'R'))
-        self.assertEqual(str(pt.toMsg()), str(GeoPoint(lat, lon, alt)),
+        self.assertEqual(str(pt.toMsg()), str(GeoPoint(latitude=lat, longitude=lon, altitude=alt)),
                          msg='GeoPoint conversion failed for: ' + str(pt))
         point_xy = pt.toPoint()
         self.assertAlmostEqual(point_xy.x, 622159.338, places = 3)
@@ -53,6 +56,5 @@ class TestUTMPoint(unittest.TestCase):
         self.assertAlmostEqual(point_xy.z, 0.0, places = 3)
  
 if __name__ == '__main__':
-    import rosunit
-    PKG='geodesy'
-    rosunit.unitrun(PKG, 'test_utm_py', TestUTMPoint) 
+    runner = unittest.TextTestRunner(verbosity=3)
+    result = runner.run(suite)

--- a/geodesy/tests/test_wu_point.py
+++ b/geodesy/tests/test_wu_point.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
 
 import unittest
+import uuid
 
 from geographic_msgs.msg import GeographicMap
 from geographic_msgs.msg import GeoPoint
 from geographic_msgs.msg import WayPoint
 from geometry_msgs.msg import Point
-from uuid_msgs.msg import UniqueID
+from unique_identifier_msgs.msg import UUID
 
 from geodesy.wu_point import *
+
+suite = unittest.TestSuite()
+
 
 def fromLatLong(lat, lon, alt=float('nan')):
     """Generate WayPoint from latitude, longitude and (optional) altitude.
@@ -96,15 +100,18 @@ class TestWuPoint(unittest.TestCase):
         for i in range(len(uuids)):
             latlon = GeoPoint(latitude = latitudes[i],
                               longitude = longitudes[i])
-            points.append(WayPoint(id = UniqueID(uuid = uuids[i]),
+            points.append(WayPoint(id = UUID(uuid = list(uuid.UUID(uuids[i]).bytes)),
                                    position = latlon))
     
         # test iterator
         wupts = WuPointSet(points)
         i = 0
         for w in wupts:
-            self.assertEqual(w.uuid(), uuids[i])
-            self.assertEqual(wupts[uuids[i]].uuid(), uuids[i])
+            uuid_msg = UUID(uuid=list(uuid.UUID(uuids[i]).bytes))
+
+            self.assertEqual(str(uuid.UUID(bytes=bytes(w.uuid()), version=5)), uuids[i])
+            self.assertEqual(str(uuid.UUID(bytes=bytes(wupts[str(uuid_msg.uuid)].uuid()), version=5)), uuids[i])
+
             self.assertAlmostEqual(w.utm.easting, eastings[i], places=3)
             self.assertAlmostEqual(w.utm.northing, northings[i], places=3)
             point_xy = w.toPointXY()
@@ -119,19 +126,20 @@ class TestWuPoint(unittest.TestCase):
         self.assertFalse(bogus in wupts)
         self.assertEqual(wupts.get(bogus), None)
 
-        uu = uuids[1]
+        uu = str(UUID(uuid=list(uuid.UUID(uuids[1]).bytes)).uuid)
         self.assertTrue(uu in wupts)
         wpt = wupts[uu]
-        self.assertEqual(wpt.uuid(), uu)
+        self.assertEqual(str(wpt.uuid()), uu)
+
         self.assertNotEqual(wupts.get(uu), None)
-        self.assertEqual(wupts.get(uu).uuid(), uu)
+        self.assertEqual(str(wupts.get(uu).uuid()), uu)
 
         # test index() function
         for i in range(len(uuids)):
-            self.assertEqual(wupts.index(uuids[i]), i)
-            self.assertEqual(wupts.points[i].id.uuid, uuids[i])
+            wpuuid = str(UUID(uuid=list(uuid.UUID(uuids[i]).bytes)).uuid)
+            self.assertEqual(wupts.index(wpuuid), i)
+            self.assertEqual(str(uuid.UUID(bytes=bytes(wupts.points[i].id.uuid), version=5)), uuids[i])
 
 if __name__ == '__main__':
-    import rosunit
-    PKG='geodesy'
-    rosunit.unitrun(PKG, 'test_xml_map_py', TestWuPoint) 
+    runner = unittest.TextTestRunner(verbosity=3)
+    result = runner.run(suite)

--- a/geodesy/tests/test_wu_point.py
+++ b/geodesy/tests/test_wu_point.py
@@ -127,7 +127,7 @@ class TestWuPoint(unittest.TestCase):
         self.assertEqual(wupts.get(uu).uuid(), uu)
 
         # test index() function
-        for i in xrange(len(uuids)):
+        for i in range(len(uuids)):
             self.assertEqual(wupts.index(uuids[i]), i)
             self.assertEqual(wupts.points[i].id.uuid, uuids[i])
 


### PR DESCRIPTION
Some minor py3 fixes to be able to use this for `open_street_map` package.

The most invasive one is this one: 

```
for wid in range(self.n_points):
            self.way_point_ids[str(self.points[wid].id.uuid)] = wid
```
`self.points[wid].id.uuid` is a list, and a list can't be a key in a dict, so need to convert to string. Don't think it will ever affect anything in a negative way, but just wanted to highlight it.

Other changes should be straightforward.

edit: saw that there was an issue, to get this to work for both py2 and py3, and these changes would actually work in both I think (haven't tested py2 though)