### PR TITLE
Force a GeoPoint and GeoPose coordinate to be converted in a specific zonal frame c++

### DIFF
--- a/geodesy/include/geodesy/utm.h
+++ b/geodesy/include/geodesy/utm.h
@@ -100,7 +100,7 @@ class UTMPoint
     zone(that.zone),
     band(that.band)
   {}
-  
+
   UTMPoint(const geographic_msgs::GeoPoint &pt);
 
   /** Create a flattened 2-D grid point. */
@@ -124,7 +124,7 @@ class UTMPoint
 
   // data members
   double easting;           ///< easting within grid zone [meters]
-  double northing;          ///< northing within grid zone [meters] 
+  double northing;          ///< northing within grid zone [meters]
   double altitude;          ///< altitude above ellipsoid [meters] or NaN
   uint8_t zone;             ///< UTM longitude zone number
   char   band;              ///< MGRS latitude band letter
@@ -147,7 +147,7 @@ class UTMPose
     position(that.position),
     orientation(that.orientation)
   {}
-  
+
   /** Create from a WGS 84 geodetic pose. */
   UTMPose(const geographic_msgs::GeoPose &pose):
     position(pose.position),
@@ -175,8 +175,10 @@ class UTMPose
 }; // class UTMPose
 
 // conversion function prototypes
-void fromMsg(const geographic_msgs::GeoPoint &from, UTMPoint &to);
-void fromMsg(const geographic_msgs::GeoPose &from, UTMPose &to);
+void fromMsg(const geographic_msgs::GeoPoint &from, UTMPoint &to,
+        const bool& force_zone=false, const char& band='A', const uint8_t& zone=0 );
+void fromMsg(const geographic_msgs::GeoPose &from, UTMPose &to,
+        const bool& force_zone=false, const char& band='A', const uint8_t& zone=0 );
 geographic_msgs::GeoPoint toMsg(const UTMPoint &from);
 geographic_msgs::GeoPose toMsg(const UTMPose &from);
 

--- a/geodesy/tests/test_utm.cpp
+++ b/geodesy/tests/test_utm.cpp
@@ -442,6 +442,32 @@ TEST(OStream, pose)
   EXPECT_EQ(out.str(), expected);
 }
 
+TEST(ForceUTMZone, point)
+{
+
+    geographic_msgs::GeoPoint zone2, zone3;
+    zone2.latitude=24.02;
+    zone2 = geodesy::toMsg(24.02, 5.999);
+    zone3 = geodesy::toMsg(24.02, 6.001);
+    geodesy::UTMPoint pt2, pt3, pt4;
+    geodesy::fromMsg(zone2, pt2);
+    geodesy::fromMsg(zone3, pt3);
+
+    EXPECT_FALSE(geodesy::sameGridZone(pt2, pt3) );
+
+    double diffx = pt2.easting - pt3.easting;
+    double diffy = pt2.northing - pt3.northing;
+    double distance = std::sqrt(diffx*diffx + diffy*diffy);
+
+    //Now force the pt3 into pt2's grid zone
+    geodesy::fromMsg(zone3, pt4, true, pt2.band, pt2.zone);
+    diffx = pt2.easting - pt4.easting;
+    diffy = pt2.northing - pt4.northing;
+    double distance2 = std::sqrt(diffx*diffx + diffy*diffy);
+    ROS_INFO("Prev Distance %f, Actual Distance %f", distance, distance2);
+    EXPECT_LT(distance2, distance);
+}
+
 // Run all the tests that were declared with TEST()
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Theres been a similar request #20  to do this in the python code. This pr does it for cpp. Basically it addresses the issue of smoothness when a vehicle transitions space that straddles two utm zones. Without this change, a jump across zones can cause a euclidean distance to be several hunreds of thousands of meters apart. This change ensures that the transition is as smooth as possible. 

It gives the user the ability to force the conversion to use a specific zone and band. Test case is provided, but it is noted that forcing a specific band actually doesn't do anything or change the calculation done. 
