### PR TITLE
Added GeoPoseWithCovariance and GeoPoseWithCovarianceStamped messages

### DIFF
--- a/geographic_msgs/CMakeLists.txt
+++ b/geographic_msgs/CMakeLists.txt
@@ -19,7 +19,9 @@ add_message_files(
   GeoPoint.msg
   GeoPointStamped.msg
   GeoPose.msg
+  GeoPoseWithCovariance.msg
   GeoPoseStamped.msg
+  GeoPoseWithCovarianceStamped.msg
   KeyValue.msg
   MapFeature.msg
   RouteNetwork.msg

--- a/geographic_msgs/msg/GeoPoseWithCovariance.msg
+++ b/geographic_msgs/msg/GeoPoseWithCovariance.msg
@@ -1,0 +1,12 @@
+# Geographic pose, using the WGS 84 reference ellipsoid.
+#
+# Orientation uses the East-North-Up (ENU) frame of reference.
+# (But, what about singularities at the poles?)
+
+GeoPose pose
+
+# Row-major representation of the 6x6 covariance matrix
+# The orientation parameters use a fixed-axis representation.
+# In order, the parameters are:
+# (Lat, Lon, Alt, rotation about E (East) axis, rotation about N (North) axis, rotation about U (Up) axis)
+float64[36] covariance

--- a/geographic_msgs/msg/GeoPoseWithCovarianceStamped.msg
+++ b/geographic_msgs/msg/GeoPoseWithCovarianceStamped.msg
@@ -1,0 +1,2 @@
+Header header
+geographic_msgs/GeoPoseWithCovariance pose


### PR DESCRIPTION
Our group will be doing state estimation with multiple outdoor agents reporting their position with only Geographic information.  These messages would allow this capability to be more seemless having to combine NavSatFix position and covariance information with GeoPose orientation information manually.