### PR TITLE
Added GeoPoseWithCovariance and GeoPoseWithCovarianceStamped messages

### DIFF
--- a/geographic_msgs/CMakeLists.txt
+++ b/geographic_msgs/CMakeLists.txt
@@ -25,6 +25,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/GeoPointStamped.msg"
   "msg/GeoPose.msg"
   "msg/GeoPoseStamped.msg"
+  "msg/GeoPoseWithCovariance.msg"
+  "msg/GeoPoseWithCovarianceStamped.msg"
   "msg/KeyValue.msg"
   "msg/MapFeature.msg"
   "msg/RouteNetwork.msg"

--- a/geographic_msgs/msg/GeoPoseWithCovariance.msg
+++ b/geographic_msgs/msg/GeoPoseWithCovariance.msg
@@ -1,0 +1,12 @@
+# Geographic pose, using the WGS 84 reference ellipsoid.
+#
+# Orientation uses the East-North-Up (ENU) frame of reference.
+# (But, what about singularities at the poles?)
+
+GeoPose pose
+
+# Row-major representation of the 6x6 covariance matrix
+# The orientation parameters use a fixed-axis representation.
+# In order, the parameters are:
+# (Lat, Lon, Alt, rotation about E (East) axis, rotation about N (North) axis, rotation about U (Up) axis)
+float64[36] covariance

--- a/geographic_msgs/msg/GeoPoseWithCovarianceStamped.msg
+++ b/geographic_msgs/msg/GeoPoseWithCovarianceStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+geographic_msgs/GeoPoseWithCovariance pose


### PR DESCRIPTION
Our group will be doing state estimation with multiple outdoor agents reporting their position with only Geographic information. These messages would allow this capability to be more seemless having to combine NavSatFix position and covariance information with GeoPose orientation information manually.