### PR TITLE
Bump to 1.0.5

### DIFF
--- a/geodesy/package.xml
+++ b/geodesy/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>geodesy</name>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <description>
     Python and C++ interfaces for manipulating geodetic coordinates.
   </description>

--- a/geographic_info/package.xml
+++ b/geographic_info/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>geographic_info</name>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <description>
     Geographic information metapackage.
 

--- a/geographic_msgs/package.xml
+++ b/geographic_msgs/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
 
   <name>geographic_msgs</name>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <description>
      ROS messages for Geographic Information Systems.
   </description>


### PR DESCRIPTION
I'd like to have a new tag available for the next humble sync. The last PR to merge did not have a new tag generated. To get the new messages available in the humble debian, we first need this version bump. 

See here: https://discourse.ros.org/t/preparing-for-humble-sync-and-patch-release-2023-04-28/31105/2?u=rfriedm

 Note: This work was done on behalf of[ AeroVironment Inc.](https://www.avinc.com/)

