### PR TITLE
Add GeoPoint Validation

### DIFF
--- a/geographic_msgs/CMakeLists.txt
+++ b/geographic_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.5)
 project(geographic_msgs)
 
 if(NOT CMAKE_CXX_STANDARD)
@@ -39,9 +39,31 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES unique_identifier_msgs geometry_msgs std_msgs builtin_interfaces
 )
 
-add_library(validation INTERFACE)
-add_library(${PROJECT_NAME}::validation ALIAS validation)
-add_subdirectory(include)
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" rosidl_typesupport_cpp)
+
+if(TARGET "${cpp_typesupport_target}")
+  add_library(${PROJECT_NAME}::cpp_typesupport_target ALIAS ${cpp_typesupport_target})
+  add_library(validation INTERFACE)
+  add_library(${PROJECT_NAME}::validation ALIAS validation)
+  add_subdirectory(include)
+  target_link_libraries(validation INTERFACE ${PROJECT_NAME}::cpp_typesupport_target)
+
+  install(
+    TARGETS validation
+    EXPORT export_${PROJECT_NAME}
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
+
+  install(
+    DIRECTORY include/
+    DESTINATION include/${PROJECT_NAME}
+    FILES_MATCHING PATTERN "*.hpp"
+  )
+
+  ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+endif()
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -54,21 +76,6 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
-install(
-  TARGETS validation
-  EXPORT export_${PROJECT_NAME}
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-
-install(
-  DIRECTORY include/
-  DESTINATION include/${PROJECT_NAME}
-  FILES_MATCHING PATTERN "*.hpp"
-)
-
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(rosidl_default_runtime)
 
 ament_package()

--- a/geographic_msgs/CMakeLists.txt
+++ b/geographic_msgs/CMakeLists.txt
@@ -1,9 +1,8 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(geographic_msgs)
 
-# Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -40,11 +39,35 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES unique_identifier_msgs geometry_msgs std_msgs builtin_interfaces
 )
 
+add_library(validation INTERFACE)
+add_library(${PROJECT_NAME}::validation ALIAS validation)
+include(GNUInstallDirs)
+add_subdirectory(include)
+
+include(CTest)
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  add_subdirectory(test)
+endif()
+
 install(
   FILES geographic_msgs_mapping_rule.yaml
   DESTINATION share/${PROJECT_NAME}
 )
 
+install(
+  TARGETS validation
+  EXPORT export_${PROJECT_NAME}
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(rosidl_default_runtime)
 
 ament_package()

--- a/geographic_msgs/CMakeLists.txt
+++ b/geographic_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 project(geographic_msgs)
 
 if(NOT CMAKE_CXX_STANDARD)
@@ -41,10 +41,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 add_library(validation INTERFACE)
 add_library(${PROJECT_NAME}::validation ALIAS validation)
-include(GNUInstallDirs)
 add_subdirectory(include)
 
-include(CTest)
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
@@ -59,6 +57,9 @@ install(
 install(
   TARGETS validation
   EXPORT export_${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 install(

--- a/geographic_msgs/include/CMakeLists.txt
+++ b/geographic_msgs/include/CMakeLists.txt
@@ -3,13 +3,3 @@ target_include_directories(validation
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
-
-# Need to access the target from the build tree to link it in tests.
-unset(_cpp_typesupport_target)
-rosidl_get_typesupport_target(_cpp_typesupport_target
-  ${PROJECT_NAME} rosidl_typesupport_cpp
-)
-target_link_libraries(validation
-  INTERFACE
-    ${_cpp_typesupport_target}
-)

--- a/geographic_msgs/include/CMakeLists.txt
+++ b/geographic_msgs/include/CMakeLists.txt
@@ -1,0 +1,15 @@
+target_include_directories(validation
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+# Need to access the target from the build tree to link it in tests.
+unset(_cpp_typesupport_target)
+rosidl_get_typesupport_target(_cpp_typesupport_target
+  ${PROJECT_NAME} rosidl_typesupport_cpp
+)
+target_link_libraries(validation
+  INTERFACE
+    ${_cpp_typesupport_target}
+)

--- a/geographic_msgs/include/geographic_msgs/validation.hpp
+++ b/geographic_msgs/include/geographic_msgs/validation.hpp
@@ -1,0 +1,19 @@
+// Copyright 2024 Ryan Friedman BSD
+
+#pragma once
+#include <geographic_msgs/msg/geo_point.hpp>
+
+namespace geographic_msgs
+{
+
+//! @brief Return whether a GeoPoint has latitude and longitude within expected bounds.
+[[nodiscard]] inline static bool HorizontalPositionValid(const geographic_msgs::msg::GeoPoint point)
+{
+  auto const lat_valid = point.latitude <= 90.0 && point.latitude >= -90.0;
+  auto const lng_valid = point.longitude <= 180.0 && point.longitude >= -180.0;
+
+  return lat_valid && lng_valid;
+}
+
+
+}  // namespace geographic_msgs

--- a/geographic_msgs/include/geographic_msgs/validation.hpp
+++ b/geographic_msgs/include/geographic_msgs/validation.hpp
@@ -1,20 +1,4 @@
-// Copyright (c) 2024
-// AeroVironment, Inc. All rights reserved.
-
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
-
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// THIS SOFTWARE IS PROVIDED BY [Name of Organization] “AS IS” AND ANY EXPRESS OR
-// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL AeroVironment, Inc.
-// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-// OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+// Copyright 2024 Ryan Friedman
 #pragma once
 #include <geographic_msgs/msg/geo_point.hpp>
 

--- a/geographic_msgs/include/geographic_msgs/validation.hpp
+++ b/geographic_msgs/include/geographic_msgs/validation.hpp
@@ -22,7 +22,7 @@ namespace geographic_msgs
 {
 
 //! @brief Return whether a GeoPoint has latitude and longitude within expected bounds.
-[[nodiscard]] inline static bool HorizontalPositionValid(const geographic_msgs::msg::GeoPoint point)
+[[nodiscard]] inline static bool horizontalPositionValid(const geographic_msgs::msg::GeoPoint point)
 {
   auto const lat_valid = point.latitude <= 90.0 && point.latitude >= -90.0;
   auto const lng_valid = point.longitude <= 180.0 && point.longitude >= -180.0;

--- a/geographic_msgs/include/geographic_msgs/validation.hpp
+++ b/geographic_msgs/include/geographic_msgs/validation.hpp
@@ -1,4 +1,19 @@
-// Copyright 2024 Ryan Friedman BSD
+// Copyright (c) 2024
+// AeroVironment, Inc. All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+
+// Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// THIS SOFTWARE IS PROVIDED BY [Name of Organization] “AS IS” AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL AeroVironment, Inc.
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+// OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 #include <geographic_msgs/msg/geo_point.hpp>

--- a/geographic_msgs/mainpage.dox
+++ b/geographic_msgs/mainpage.dox
@@ -2,8 +2,11 @@
 \mainpage
 \htmlinclude manifest.html
 
-This package provides ROS messages for Geographic Information.  
+This package provides ROS messages for Geographic Information.
 
-It has no nodes, utilities, scripts or C++ API.
+It includes a simple validation library to validate messages have values within
+the documented bounds.
+
+It has no nodes or scripts.
 
 */

--- a/geographic_msgs/msg/GeoPoint.msg
+++ b/geographic_msgs/msg/GeoPoint.msg
@@ -1,12 +1,12 @@
 # Geographic point, using the WGS 84 reference ellipsoid.
 
 # Latitude [degrees]. Positive is north of equator; negative is south
-# (-90 <= latitude <= +90).
+# (-90.0 <= latitude <= +90.0).
 float64 latitude
 
 # Longitude [degrees]. Positive is east of prime meridian; negative is
-# west (-180 <= longitude <= +180). At the poles, latitude is -90 or
-# +90, and longitude is irrelevant, but must be in range.
+# west (-180.0 <= longitude <= +180.0). At the poles, latitude is -90.0 or
+# +90.0, and longitude is irrelevant, but must be in range.
 float64 longitude
 
 # Altitude [m]. Positive is above the WGS 84 ellipsoid (NaN if unspecified).

--- a/geographic_msgs/package.xml
+++ b/geographic_msgs/package.xml
@@ -9,7 +9,6 @@
   </description>
   <maintainer email="jack.oquin@gmail.com">Jack O'Quin</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
-  <author>Jack O'Quin</author>
   <license>BSD</license>
 
   <url>http://wiki.ros.org/geographic_msgs</url>
@@ -24,6 +23,10 @@
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
   <depend>unique_identifier_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
   <export>

--- a/geographic_msgs/package.xml
+++ b/geographic_msgs/package.xml
@@ -26,7 +26,17 @@
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <!--
+    Skip using ament_lint_auto because ament_lint_copyright does not support "BSD" license.
+    https://robotics.stackexchange.com/questions/109592/how-to-use-ament-lint-commons-ament-copyright-on-a-bsd-licensed-package-such
+    For now, the C++, CMake, and XML linters are enabled.
+   -->
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+
 
   <member_of_group>rosidl_interface_packages</member_of_group>
   <export>

--- a/geographic_msgs/test/CMakeLists.txt
+++ b/geographic_msgs/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+find_package(ament_cmake_gtest CONFIG REQUIRED)
+ament_add_gtest(validation_test test_validation.cpp)
+target_link_libraries(validation_test ${PROJECT_NAME}::validation)

--- a/geographic_msgs/test/CMakeLists.txt
+++ b/geographic_msgs/test/CMakeLists.txt
@@ -1,3 +1,5 @@
-find_package(ament_cmake_gtest CONFIG REQUIRED)
-ament_add_gtest(validation_test test_validation.cpp)
-target_link_libraries(validation_test ${PROJECT_NAME}::validation)
+if(TARGET "${cpp_typesupport_target}")
+    find_package(ament_cmake_gtest CONFIG REQUIRED)
+    ament_add_gtest(validation_test test_validation.cpp)
+    target_link_libraries(validation_test ${PROJECT_NAME}::validation)
+endif()

--- a/geographic_msgs/test/test_validation.cpp
+++ b/geographic_msgs/test/test_validation.cpp
@@ -25,7 +25,7 @@ TEST(ElevationServerCore, ValidPoints)
   geographic_msgs::msg::GeoPoint point;
   point.latitude = 1.0;
   point.longitude = 10.0;
-  EXPECT_TRUE(geographic_msgs::HorizontalPositionValid(point));
+  EXPECT_TRUE(geographic_msgs::horizontalPositionValid(point));
 }
 
 TEST(ElevationServerCore, TooFarNorth)
@@ -33,7 +33,7 @@ TEST(ElevationServerCore, TooFarNorth)
   geographic_msgs::msg::GeoPoint point;
   point.latitude = 90.01;
   point.longitude = 0.0;
-  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+  EXPECT_FALSE(geographic_msgs::horizontalPositionValid(point));
 }
 
 TEST(ElevationServerCore, TooFarSouth)
@@ -41,7 +41,7 @@ TEST(ElevationServerCore, TooFarSouth)
   geographic_msgs::msg::GeoPoint point;
   point.latitude = -90.01;
   point.longitude = 0.0;
-  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+  EXPECT_FALSE(geographic_msgs::horizontalPositionValid(point));
 }
 
 TEST(ElevationServerCore, TooFarWest)
@@ -49,7 +49,7 @@ TEST(ElevationServerCore, TooFarWest)
   geographic_msgs::msg::GeoPoint point;
   point.latitude = 0.0;
   point.longitude = -180.1;
-  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+  EXPECT_FALSE(geographic_msgs::horizontalPositionValid(point));
 }
 
 TEST(ElevationServerCore, TooFarEast)
@@ -57,7 +57,7 @@ TEST(ElevationServerCore, TooFarEast)
   geographic_msgs::msg::GeoPoint point;
   point.latitude = 0.0;
   point.longitude = 180.1;
-  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+  EXPECT_FALSE(geographic_msgs::horizontalPositionValid(point));
 }
 
 TEST(ElevationServerCore, NorthPole)
@@ -65,7 +65,7 @@ TEST(ElevationServerCore, NorthPole)
   geographic_msgs::msg::GeoPoint point;
   point.latitude = 90.0;
   point.longitude = 42.0;
-  EXPECT_TRUE(geographic_msgs::HorizontalPositionValid(point));
+  EXPECT_TRUE(geographic_msgs::horizontalPositionValid(point));
 }
 
 TEST(ElevationServerCore, SouthPole)
@@ -73,7 +73,7 @@ TEST(ElevationServerCore, SouthPole)
   geographic_msgs::msg::GeoPoint point;
   point.latitude = -90.0;
   point.longitude = 42.0;
-  EXPECT_TRUE(geographic_msgs::HorizontalPositionValid(point));
+  EXPECT_TRUE(geographic_msgs::horizontalPositionValid(point));
 }
 
 TEST(ElevationServerCore, NorthPoleInvalidLng)
@@ -81,7 +81,7 @@ TEST(ElevationServerCore, NorthPoleInvalidLng)
   geographic_msgs::msg::GeoPoint point;
   point.latitude = 90.0;
   point.longitude = 999.0;
-  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+  EXPECT_FALSE(geographic_msgs::horizontalPositionValid(point));
 }
 
 TEST(ElevationServerCore, SouthPoleInvalidLng)
@@ -89,5 +89,5 @@ TEST(ElevationServerCore, SouthPoleInvalidLng)
   geographic_msgs::msg::GeoPoint point;
   point.latitude = -90.0;
   point.longitude = -999.0;
-  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+  EXPECT_FALSE(geographic_msgs::horizontalPositionValid(point));
 }

--- a/geographic_msgs/test/test_validation.cpp
+++ b/geographic_msgs/test/test_validation.cpp
@@ -1,4 +1,19 @@
-// Copyright 2024 Ryan Friedman BSD
+// Copyright (c) 2024
+// AeroVironment, Inc. All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+
+// Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// THIS SOFTWARE IS PROVIDED BY [Name of Organization] “AS IS” AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL AeroVironment, Inc.
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+// OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <gtest/gtest.h>
 #include <geographic_msgs/msg/geo_point.hpp>

--- a/geographic_msgs/test/test_validation.cpp
+++ b/geographic_msgs/test/test_validation.cpp
@@ -1,0 +1,78 @@
+// Copyright 2024 Ryan Friedman BSD
+
+#include <gtest/gtest.h>
+#include <geographic_msgs/msg/geo_point.hpp>
+#include <geographic_msgs/validation.hpp>
+
+
+TEST(ElevationServerCore, ValidPoints)
+{
+  geographic_msgs::msg::GeoPoint point;
+  point.latitude = 1.0;
+  point.longitude = 10.0;
+  EXPECT_TRUE(geographic_msgs::HorizontalPositionValid(point));
+}
+
+TEST(ElevationServerCore, TooFarNorth)
+{
+  geographic_msgs::msg::GeoPoint point;
+  point.latitude = 90.01;
+  point.longitude = 0.0;
+  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+}
+
+TEST(ElevationServerCore, TooFarSouth)
+{
+  geographic_msgs::msg::GeoPoint point;
+  point.latitude = -90.01;
+  point.longitude = 0.0;
+  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+}
+
+TEST(ElevationServerCore, TooFarWest)
+{
+  geographic_msgs::msg::GeoPoint point;
+  point.latitude = 0.0;
+  point.longitude = -180.1;
+  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+}
+
+TEST(ElevationServerCore, TooFarEast)
+{
+  geographic_msgs::msg::GeoPoint point;
+  point.latitude = 0.0;
+  point.longitude = 180.1;
+  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+}
+
+TEST(ElevationServerCore, NorthPole)
+{
+  geographic_msgs::msg::GeoPoint point;
+  point.latitude = 90.0;
+  point.longitude = 42.0;
+  EXPECT_TRUE(geographic_msgs::HorizontalPositionValid(point));
+}
+
+TEST(ElevationServerCore, SouthPole)
+{
+  geographic_msgs::msg::GeoPoint point;
+  point.latitude = -90.0;
+  point.longitude = 42.0;
+  EXPECT_TRUE(geographic_msgs::HorizontalPositionValid(point));
+}
+
+TEST(ElevationServerCore, NorthPoleInvalidLng)
+{
+  geographic_msgs::msg::GeoPoint point;
+  point.latitude = 90.0;
+  point.longitude = 999.0;
+  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+}
+
+TEST(ElevationServerCore, SouthPoleInvalidLng)
+{
+  geographic_msgs::msg::GeoPoint point;
+  point.latitude = -90.0;
+  point.longitude = -999.0;
+  EXPECT_FALSE(geographic_msgs::HorizontalPositionValid(point));
+}

--- a/geographic_msgs/test/test_validation.cpp
+++ b/geographic_msgs/test/test_validation.cpp
@@ -1,19 +1,4 @@
-// Copyright (c) 2024
-// AeroVironment, Inc. All rights reserved.
-
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
-
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// THIS SOFTWARE IS PROVIDED BY [Name of Organization] “AS IS” AND ANY EXPRESS OR
-// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL AeroVironment, Inc.
-// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-// OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright 2024 Ryan Friedman
 
 #include <gtest/gtest.h>
 #include <geographic_msgs/msg/geo_point.hpp>


### PR DESCRIPTION
# Purpose

GeoPoint is a message type with comments in the header on the limits for the values. I have a lot of code duplication in ROS nodes by checking this over and over. 

As a solution, I propose packaging a validation function that can be used by anyone.

# Details

I added a new CMake target, along with tests.  The validation function uses [[nodiscard]] so I bumped up the C++ requirement.
It also includes a comprehensive test suite for all the cases in the comments. 

# Copyright

The repo is set to BSD, but I can't figure out what to put in the C++ files to make the ament_copyright linter happy.

# Attribution

This works is contributed from `AeroVironment, Inc`, under the existing BSD license of the repo. 
I did not add license texts to the work here because "BSD" is not a valid license, and the ROS tooling does not support unknown licenses. Regardless, the files contributed into this PR fall under the license declared in the package.xml, or any newer version of BSD if the maintainers desire it.

Details: https://robotics.stackexchange.com/questions/109592/how-to-use-ament-lint-commons-ament-copyright-on-a-bsd-licensed-package-such/109593#109593

# Related

Tully did the same thing here: https://github.com/ros2/common_interfaces/blob/rolling/sensor_msgs/CMakeLists.txt#L68

See this PR: https://github.com/ros2/common_interfaces/pull/183

Maybe we could get one of their reviewers to give this a pass?