### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/geodesy/CMakeLists.txt
+++ b/geodesy/CMakeLists.txt
@@ -32,7 +32,7 @@ ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR src/${PROJECT_NAME})
 
 # build C++ coordinate conversion library
 add_library(geoconv STATIC src/conv/utm_conversions.cpp)
-ament_target_dependencies(geoconv 
+target_link_libraries(geoconv PUBLIC
   ${dependencies}
 )
 


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
